### PR TITLE
Update deprecated sklearn to scikit-learn instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ scikit-image
 imageio-ffmpeg
 PyYAML==5.3.1
 tqdm
-sklearn
+scikit-learn
 pandas
 moviepy
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ scikit-image
 imageio-ffmpeg
 PyYAML==5.3.1
 tqdm
-sklearn
+scikit-learn
 pandas
 moviepy


### PR DESCRIPTION
While installing the required libs using `pip install -r requirements.txt` `pip` complains that the `sklearn` PyPI package is deprecated. Seems that [it was completely phased out recently](https://github.com/scikit-learn/sklearn-pypi-package).

Updating the package name lets it install scikit-learn properly. 